### PR TITLE
New manifest format

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -83,6 +83,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'size_lsi', label: 'File Size'
     config.add_show_field 'type_tesi', label: 'File Type'
     config.add_show_field 'shares_ssim', lable: 'Shares'
+    config.add_show_field 'packageid_tesig', lable: "Package ID"
     
 
     
@@ -112,10 +113,10 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field("File Type") do |field|
+    config.add_search_field("Package Id") do |field|
       field.solr_parameters = {
-        qf: 'type_tei',
-        pf: 'type_tei'
+        qf: 'packageid_tesig',
+        pf: 'packageid_tesig'
       }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -54,6 +54,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'depositor_ssi', label: 'Depositor'
     config.add_facet_field 'collection_ssi', label: 'Collection'
     config.add_facet_field 'type_ssi', label: 'Type'
+    config.add_facet_field 'packageid_ssi', label: "Package ID", show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -83,7 +84,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'size_lsi', label: 'File Size'
     config.add_show_field 'type_tesi', label: 'File Type'
     config.add_show_field 'shares_ssim', lable: 'Shares'
-    config.add_show_field 'packageid_tesig', lable: "Package ID"
+    config.add_show_field 'packageid_ssi', label: "Package ID", link_to_search: true
     
 
     
@@ -115,8 +116,8 @@ class CatalogController < ApplicationController
 
     config.add_search_field("Package Id") do |field|
       field.solr_parameters = {
-        qf: 'packageid_tesig',
-        pf: 'packageid_tesig'
+        qf: 'packageid_ssi',
+        pf: 'packageid_ssi'
       }
     end
 

--- a/lib/tasks/manifest.rake
+++ b/lib/tasks/manifest.rake
@@ -16,7 +16,9 @@ def create_solr_doc(collection, file, package)
   urn = package['package_id']
   package_prefix = "#{urn[9..10]}/#{urn[11..12]}/#{urn[13..16]}#{urn[18..21]}#{urn[23..26]}#{urn[28..31]}#{urn[33..-1]}"
 
-  fullpath_ssi = "#{package_prefix}/#{filepath}"
+  # ultimately we'll want to include the package in the path, but not yet
+  # fullpath_ssi = "#{package_prefix}/#{filepath}"
+  fullpath_ssi = "#{filepath}"
 
   all_locations = ((collection['locations'] || []) + (package['locations'] || []))
                   .map { |location| "#{location}/#{fullpath_ssi}" }
@@ -121,9 +123,6 @@ namespace :manifest do
     # manifest consists of an array of collections
 
     solrdocs = []
-
-    # TODO: Manifest is a single collection, not array of collections.
-    # See https://github.com/cul-it/cular-metadata for details
 
     collection = JSON.parse(file)
 

--- a/lib/tasks/manifest.rake
+++ b/lib/tasks/manifest.rake
@@ -40,7 +40,7 @@ def create_solr_doc(collection, file, package)
     steward_ssi: (collection['steward'] || 'No collection steward'),
     rights_ssi: collection['rights'],
     # package-level stuff
-    packageid_tesig: package['package_id'],
+    packageid_ssi: package['package_id'],
     bibid_ssi: (package['bibid'] || 'No bibid'),
     localid_ssi: (package['local_id'] || ' No local id'),
     shares_ssim: shares_ssim,


### PR DESCRIPTION
This request makes changes for the new manifest format. Specifically, it:

* makes `rake manifest:solrize` read the new manifest format and outputs SOLR documents with the data from the new format.
* Updates the views in Blacklight to use the new information.
* facets on the new package_id to allow for looking at all the files in a package.